### PR TITLE
enable 'Allow-Credentials' CORS header for AJAX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orator",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Restful web API server.",
   "main": "source/Orator.js",
   "scripts": {

--- a/source/Orator.js
+++ b/source/Orator.js
@@ -151,7 +151,7 @@ var Orator = function()
 		{
 			if (pSettings.RestifyParsers.CORS)
 			{
-				pWebServer.use(libRestify.CORS());
+				pWebServer.use(libRestify.CORS({credentials:true})); //by default if CORS is enabled, then also enable 'Allow-Credentials' header for AJAX
 			}
 			if (pSettings.RestifyParsers.FullResponse)
 			{


### PR DESCRIPTION
Published to npm @v1.0.8