### PR TITLE
Add interceptors for error transformation and error handling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orator",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Restful web API server. Using restify 6.",
   "main": "source/Orator.js",
   "scripts": {
@@ -10,6 +10,7 @@
     "coverage-cluster": "./node_modules/istanbul/lib/cli.js cover --dir ./coverage/cluster ./node_modules/mocha/bin/_mocha -- --exit -u tdd -R spec ./test/Orator_cluster_test.js.deferred",
     "coverage-report": "./node_modules/istanbul/lib/cli.js report",
     "test": "npm run test-normal && npm run test-cluster",
+    "tests": "mocha --exit -u tdd -R spec -g",
     "test-normal": "./node_modules/mocha/bin/_mocha --exit -u tdd -R spec",
     "test-cluster": "./node_modules/mocha/bin/_mocha --exit -u tdd -R spec ./test/Orator_cluster_test.js.deferred"
   },

--- a/test/Orator-proxy_tests.js
+++ b/test/Orator-proxy_tests.js
@@ -16,12 +16,12 @@ var _MockSettings = (
 {
 	Product: 'MockOratorAlternate',
 	ProductVersion: '0.0.0',
-	APIServerPort: 8181
+	APIServerPort: 8181,
 });
 
 suite
 (
-	'Orator',
+	'Orator Proxy',
 	function()
 	{
 		var _Orator;

--- a/test/Orator_logging_tests.js
+++ b/test/Orator_logging_tests.js
@@ -15,7 +15,7 @@ var libSuperTest = require('supertest');
 var _MockSettings = (
 {
 	Product: 'MockOratorRequestLogging',
-	APIServerPort: 8085,
+	APIServerPort: 8985,
 	Profiling: (
 		{
 			// Tracelog is just log-based request timing encapsulation.
@@ -83,7 +83,7 @@ suite
 							}
 						);
 						_Orator.startWebServer();
-						libSuperTest('http://localhost:8085/')
+						libSuperTest(`http://localhost:${_MockSettings.APIServerPort}/`)
 						.get('PINGOLo')
 						.end(
 							function (pError, pResponse)
@@ -98,7 +98,7 @@ suite
 									Expect(pResponse.text)
 										.to.contain('Loggo');
 								}
-								libSuperTest('http://localhost:8085/')
+								libSuperTest(`http://localhost:${_MockSettings.APIServerPort}/`)
 								.get('PINataGOLo')
 								.end(
 									function (pError, pResponse)
@@ -129,7 +129,7 @@ suite
 					'uncaught exceptions should throw properly.',
 					function(fDone)
 					{
-						libSuperTest('http://localhost:8085/')
+						libSuperTest(`http://localhost:${_MockSettings.APIServerPort}/`)
 						.get('PINataGOLo')
 						.end(
 							function (pError, pResponse)
@@ -156,7 +156,7 @@ suite
 					'rejected promises should throw properly.',
 					function(fDone)
 					{
-						libSuperTest('http://localhost:8085/')
+						libSuperTest(`http://localhost:${_MockSettings.APIServerPort}/`)
 						.get('PINataGOLo_promise')
 						.end(
 							function (pError, pResponse)


### PR DESCRIPTION
Motivation is to allow us to customize this externally without making more changes to this package.

NOTE: one test is broken (with proxying), but it was broken before. Briefly looked at it and it seems like an external behavior change.

Broken test:

```mocha
  19 passing (749ms)
  1 failing

  1) Orator Proxy
       Basic Server Start
         Test proxy POST request, verify http statusCode result:

      Uncaught AssertionError: expected 404 to equal 405
      + expected - actual

      -404
      +405

      at Test.<anonymous> (test/Orator-proxy_tests.js:174:14)
      at Test.assert (node_modules/supertest/lib/test.js:181:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /home/alex/dev/orator_/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:718:3)
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/index.js:906:18)
      at IncomingMessage.emit (node:events:381:22)
      at IncomingMessage.emit (node:domain:470:12)
      at endReadableNT (node:internal/streams/readable:1307:12)
      at processTicksAndRejections (node:internal/process/task_queues:81:21)
```

Broken test repro based on quick logging:

```sh
alex@ganondorf:~/dev/orator (=) % curl -i -X POST "https://www.google.com/search" \
-H        'content-type: application/json' \
-H        'user-agent: node-superagent/3.8.2' \
-H        'accept-encoding: gzip, deflate' \
-H        'host: www.google.com'
HTTP/2 404
date: Mon, 15 Apr 2024 01:11:07 GMT
content-type: text/html
server: HTTP server (unknown)
content-length: 49
x-xss-protection: 0
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000

<html><body><h1>404 Not Found</h1></body></html>
```

If instead I capture a "real" browser request and just change it over to a POST, it gives a 405.