### PR TITLE
Delegate the invocation of the callback passed to the restifyError event to the custom delegate.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orator",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Restful web API server. Using restify 6.",
   "main": "source/Orator.js",
   "scripts": {

--- a/source/Orator.js
+++ b/source/Orator.js
@@ -610,9 +610,9 @@ var Orator = function()
 		var handleError = function(req, res, err, callback)
 		{
 			// allow application to customize this error handling
-			if (typeof userUnhandledErrorHandler == 'function' && !userUnhandledErrorHandler(req, res, err))
+			if (typeof userUnhandledErrorHandler == 'function' && !userUnhandledErrorHandler(req, res, err, callback))
 			{
-				return callback();
+				return;
 			}
 			//the default for a string error is 'Route not found', though it isn't accurate
 			err.message = err.message.replace('Route not found: ', '');

--- a/test/Orator_basic_tests.js
+++ b/test/Orator_basic_tests.js
@@ -29,17 +29,19 @@ suite
 		let capturedReq = null;
 		let capturedRes = null;
 		let capturedErr = null;
+		let capturedCallback = null;
 
 		setup
 		(
 			function()
 			{
 				_Orator = require('../source/Orator.js').new(_MockSettings);
-				_Orator.registerUnhandledErrorHandler((req, res, err) =>
+				_Orator.registerUnhandledErrorHandler((req, res, err, callback) =>
 				{
 					capturedReq = req;
 					capturedRes = res;
 					capturedErr = err;
+					capturedCallback = callback;
 					return err.statusCode > 0;
 				});
 				_Orator.registerErrorTransformer((err) =>
@@ -291,6 +293,7 @@ suite
 								Expect(capturedReq).to.exist; // shows we called the custom error handler
 								Expect(capturedReq.RequestUUID).to.be.a('string'); // so we can log this from the handler
 								Expect(capturedRes).to.exist; // shows we called the custom error handler
+								Expect(capturedCallback).to.be.a('function');
 								Expect(capturedErr.message).to.contain('Cannot read property \'dog\'');
 								Expect(pResponse.text).to.contain('Cannot read property \'dog\'');
 


### PR DESCRIPTION
This is needed because, if you call it, restify will `res.send(err);` which fails in the case that we have already sent a response.

Testing done:

* Registered override in API service.
* Check for `res.headersSent` - if so, just end the response, don't call the callback.

Result:

* Service does not crash.